### PR TITLE
UpdateTrustedProxiesMiddleware to support CIDR blocks

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -41,5 +41,5 @@ func init() {
 	rootCmd.AddCommand(serverCmd)
 
 	serverCmd.Flags().StringVarP(&listenPort, "port", "P", "80", "Listen port")
-	serverCmd.Flags().StringArrayVarP(&allowIP, "allow-ip", "I", []string{}, "ip to allow")
+	serverCmd.Flags().StringArrayVarP(&allowIP, "allow-ip", "I", []string{}, "IP addresses and CIDR blocks to allow; example: 192.168.0.1 or 0.0.0.0/0, 10.0.0.0/8")
 }


### PR DESCRIPTION
P 주소 및 CIDR 블록 지원을 명확히 하기 위해 --allow-ip 플래그의 도움말 메시지 개선

- --allow-ip 플래그의 도움말 메시지를 업데이트하여 IP 주소와 CIDR 블록 모두를 지원함을 표기
- 더 나은 이해를 위해 예제를 제공
- 이전: 클라이언트 IP가 신뢰할 수 있는 프록시 중 하나로 시작하는지 확인 후 next
- 이후: 클라이언트 IP와 신뢰할 수 있는 프록시를 CIDR 블록으로 파싱하고 클라이언트 IP가 신뢰할 수 있는 CIDR 범위 내에 있는지 확인함
- 유효하지 않은 IP 주소 처리 및 서브넷 마스크가 지정되지 않은 경우 /32를 추가하는 기능을 추가