### PR TITLE
Change branch from `master` to `main` in CD workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -13,7 +13,7 @@ on:
   # The "push" event could replace "merged" event.
   push:
     branches:
-      - master
+      - main
     tags:
       # Only trigger on semver shaped tags.
       - "v*.*.*"


### PR DESCRIPTION
This PR will change branch from `master` to `main` in CD workflow.

Ref #4