### PR TITLE
update : api intercept logeer

### DIFF
--- a/websrc/controllers/backupHandlers.go
+++ b/websrc/controllers/backupHandlers.go
@@ -42,7 +42,7 @@ import (
 //	@Router			/backup/objectstorage [post]
 func BackupOSPostHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("backup-objectstorage", "Export data from objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "backup-objectstorage", "Export data from objectstorage", start)
 	params := models.BackupTask{}
 	if !getDataWithReBind(logger, start, ctx, &params) {
 		return ctx.JSON(http.StatusOK, models.BasicResponse{
@@ -85,7 +85,7 @@ func BackupRDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migmysql", "Export data from mysql", start)
+	logger, logstrings := pageLogInit(ctx, "migmysql", "Export data from mysql", start)
 
 	params := models.BackupTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -173,7 +173,7 @@ func BackupNRDBPostHandler(ctx echo.Context) error {
 	var err error
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("backup-nrdb", "backup data from nrdb", start)
+	logger, logstrings := pageLogInit(ctx, "backup-nrdb", "backup data from nrdb", start)
 
 	params := models.BackupTask{}
 	if !getDataWithReBind(logger, start, ctx, &params) {

--- a/websrc/controllers/generateHandlers.go
+++ b/websrc/controllers/generateHandlers.go
@@ -42,7 +42,7 @@ func GenerateLinuxPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genlinux", "Create dummy data in linux", start)
+	logger, logstrings := pageLogInit(ctx, "genlinux", "Create dummy data in linux", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -89,7 +89,7 @@ func GenerateWindowsPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genwindows", "Create dummy data in windows", start)
+	logger, logstrings := pageLogInit(ctx, "genwindows", "Create dummy data in windows", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -143,7 +143,7 @@ type GenerateS3PostHandlerResponseBody struct {
 func GenerateS3PostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genS3", "Create dummy data and import to s3", start)
+	logger, logstrings := pageLogInit(ctx, "genS3", "Create dummy data and import to s3", start)
 
 	params := GenarateTask{}
 	if !getDataWithReBind(logger, start, ctx, &params) {
@@ -211,7 +211,7 @@ func GenerateS3PostHandler(ctx echo.Context) error {
 func GenerateGCPPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genGCP", "Create dummy data and import to gcp", start)
+	logger, logstrings := pageLogInit(ctx, "genGCP", "Create dummy data and import to gcp", start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -279,7 +279,7 @@ func GenerateGCPPostHandler(ctx echo.Context) error {
 func GenerateNCPPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genNCP", "Create dummy data and import to ncp objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "genNCP", "Create dummy data and import to ncp objectstorage", start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -346,7 +346,7 @@ func GenerateNCPPostHandler(ctx echo.Context) error {
 func GenerateMySQLPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genmysql", "Create dummy data and import to mysql", start)
+	logger, logstrings := pageLogInit(ctx, "genmysql", "Create dummy data and import to mysql", start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -446,7 +446,7 @@ func GenerateMySQLPostHandler(ctx echo.Context) error {
 func GenerateDynamoDBPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("gendynamodb", "Create dummy data and import to dynamoDB", start)
+	logger, logstrings := pageLogInit(ctx, "gendynamodb", "Create dummy data and import to dynamoDB", start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -520,8 +520,9 @@ func GenerateDynamoDBPostHandler(ctx echo.Context) error {
 //	@Router			/generate/firestore [post]
 func GenerateFirestorePostHandler(ctx echo.Context) error {
 	start := time.Now()
-
-	logger, logstrings := pageLogInit("genfirestore", "Create dummy data and import to firestoreDB", start)
+	pageName := "genfirestore"
+	pageInfo := "Create dummy data and import to firestoreDB"
+	logger, logstrings := pageLogInit(ctx, pageName, pageInfo, start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -597,7 +598,7 @@ func GenerateFirestorePostHandler(ctx echo.Context) error {
 func GenerateMongoDBPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genmongodb", "Create dummy data and import to mongoDB", start)
+	logger, logstrings := pageLogInit(ctx, "genmongodb", "Create dummy data and import to mongoDB", start)
 
 	params := GenarateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/migrationGCPHandlers.go
+++ b/websrc/controllers/migrationGCPHandlers.go
@@ -39,7 +39,7 @@ import (
 func MigrationGCPToLinuxPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miggcplin", "Export gcp data to windows", start)
+	logger, logstrings := pageLogInit(ctx, "miggcplin", "Export gcp data to windows", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -95,7 +95,7 @@ func MigrationGCPToLinuxPostHandler(ctx echo.Context) error {
 func MigrationGCPToWindowsPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miggcpwin", "Export gcp data to windows", start)
+	logger, logstrings := pageLogInit(ctx, "miggcpwin", "Export gcp data to windows", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -150,7 +150,7 @@ func MigrationGCPToWindowsPostHandler(ctx echo.Context) error {
 func MigrationGCPToS3PostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genlinux", "Export gcp data to s3", start)
+	logger, logstrings := pageLogInit(ctx, "genlinux", "Export gcp data to s3", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -211,7 +211,7 @@ func MigrationGCPToS3PostHandler(ctx echo.Context) error {
 func MigrationGCPToNCPPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miggcpncp", "Export gcp data to ncp objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "miggcpncp", "Export gcp data to ncp objectstorage", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/migrationHandlers.go
+++ b/websrc/controllers/migrationHandlers.go
@@ -39,7 +39,7 @@ import (
 func MigrationLinuxToS3PostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miglins3", "Import linux data to s3", start)
+	logger, logstrings := pageLogInit(ctx, "miglins3", "Import linux data to s3", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -95,7 +95,7 @@ func MigrationLinuxToS3PostHandler(ctx echo.Context) error {
 func MigrationLinuxToGCPPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miglingcp", "Import linux data to gcp", start)
+	logger, logstrings := pageLogInit(ctx, "miglingcp", "Import linux data to gcp", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -156,7 +156,7 @@ func MigrationLinuxToNCPPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("miglinncp", "Import linux data to ncp objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "miglinncp", "Import linux data to ncp objectstorage", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -214,7 +214,7 @@ func MigrationWindowsToS3PostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migwins3", "Import windows data to s3", start)
+	logger, logstrings := pageLogInit(ctx, "migwins3", "Import windows data to s3", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusOK, models.BasicResponse{
@@ -274,7 +274,7 @@ func MigrationWindowsToS3PostHandler(ctx echo.Context) error {
 func MigrationWindowsToGCPPostHandler(ctx echo.Context) error {
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migwingcp", "Import windows data to gcp", start)
+	logger, logstrings := pageLogInit(ctx, "migwingcp", "Import windows data to gcp", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -331,7 +331,7 @@ func MigrationWindowsToNCPPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migwinncp", "Import linux data to ncp objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "migwinncp", "Import linux data to ncp objectstorage", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -387,7 +387,7 @@ func MigrationMySQLPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migmysql", "Import mysql to mysql", start)
+	logger, logstrings := pageLogInit(ctx, "migmysql", "Import mysql to mysql", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/migrationNCPHandlers.go
+++ b/websrc/controllers/migrationNCPHandlers.go
@@ -40,7 +40,7 @@ func MigrationNCPToLinuxPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migncplin", "Export ncp data to linux", start)
+	logger, logstrings := pageLogInit(ctx, "migncplin", "Export ncp data to linux", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -96,7 +96,7 @@ func MigrationNCPToWindowsPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migncpwin", "Export ncp data to windows", start)
+	logger, logstrings := pageLogInit(ctx, "migncpwin", "Export ncp data to windows", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -152,7 +152,7 @@ func MigrationNCPToS3PostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migncps3", "Export ncp data to s3", start)
+	logger, logstrings := pageLogInit(ctx, "migncps3", "Export ncp data to s3", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -215,7 +215,7 @@ func MigrationNCPToGCPPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migncpgcp", "Export ncp data to gcp", start)
+	logger, logstrings := pageLogInit(ctx, "migncpgcp", "Export ncp data to gcp", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/migrationNoSqlHandlers.go
+++ b/websrc/controllers/migrationNoSqlHandlers.go
@@ -38,7 +38,7 @@ func MigrationDynamoDBToFirestorePostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migDNFS", "Export dynamoDB data to firestoreDB", start)
+	logger, logstrings := pageLogInit(ctx, "migDNFS", "Export dynamoDB data to firestoreDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -98,7 +98,7 @@ func MigrationDynamoDBToMongoDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migDNMG", "Export dynamoDB data to mongoDB", start)
+	logger, logstrings := pageLogInit(ctx, "migDNMG", "Export dynamoDB data to mongoDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -158,7 +158,7 @@ func MigrationFirestoreToDynamoDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migFSDN", "Export firestoreDB data to dynamoDB", start)
+	logger, logstrings := pageLogInit(ctx, "migFSDN", "Export firestoreDB data to dynamoDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -218,7 +218,7 @@ func MigrationFirestoreToMongoDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migFSMG", "Export firestoreDB data to mongoDB", start)
+	logger, logstrings := pageLogInit(ctx, "migFSMG", "Export firestoreDB data to mongoDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -278,7 +278,7 @@ func MigrationMongoDBToDynamoDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migMGDN", "Export mongoDB data to dynamoDB", start)
+	logger, logstrings := pageLogInit(ctx, "migMGDN", "Export mongoDB data to dynamoDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -338,7 +338,7 @@ func MigrationMongoDBToFirestorePostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migMGFS", "Export mongoDB data to firestoreDB", start)
+	logger, logstrings := pageLogInit(ctx, "migMGFS", "Export mongoDB data to firestoreDB", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/migrationS3Handlers.go
+++ b/websrc/controllers/migrationS3Handlers.go
@@ -39,7 +39,7 @@ func MigrationS3ToLinuxPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migs3lin", "Export s3 data to linux", start)
+	logger, logstrings := pageLogInit(ctx, "migs3lin", "Export s3 data to linux", start)
 
 	if !osCheck(logger, start, "linux") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -94,7 +94,7 @@ func MigrationS3ToWindowsPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("genlinux", "Export s3 data to windows", start)
+	logger, logstrings := pageLogInit(ctx, "genlinux", "Export s3 data to windows", start)
 
 	if !osCheck(logger, start, "windows") {
 		return ctx.JSON(http.StatusBadRequest, models.BasicResponse{
@@ -149,7 +149,7 @@ func MigrationS3ToGCPPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migs3gcp", "Export s3 data to gcp", start)
+	logger, logstrings := pageLogInit(ctx, "migs3gcp", "Export s3 data to gcp", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -210,7 +210,7 @@ func MigrationS3ToNCPPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("migs3ncp", "Export s3 data to ncp objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "migs3ncp", "Export s3 data to ncp objectstorage", start)
 
 	params := MigrateTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {

--- a/websrc/controllers/pageHandlers.go
+++ b/websrc/controllers/pageHandlers.go
@@ -37,7 +37,8 @@ func MainGetHandler(ctx echo.Context) error {
 // Page handlers related to Dashboard data
 
 func DashBoardHandler(ctx echo.Context) error {
-	logger := getLogger("dashboard")
+	logger := getLoggerFromContext(ctx)
+
 	logger.Info().Msg("dashboard get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "dashboard",
@@ -53,8 +54,7 @@ func DashBoardHandler(ctx echo.Context) error {
 // Page handlers related to generate data
 
 func GenerateLinuxGetHandler(ctx echo.Context) error {
-
-	logger := getLogger("genlinux")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genlinux get page accessed")
 
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
@@ -68,7 +68,7 @@ func GenerateWindowsGetHandler(ctx echo.Context) error {
 
 	// tmpPath := filepath.Join(os.TempDir(), "dummy")
 
-	logger := getLogger("genwindows")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genwindows get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-Windows",
@@ -79,7 +79,7 @@ func GenerateWindowsGetHandler(ctx echo.Context) error {
 
 func GenerateS3GetHandler(ctx echo.Context) error {
 
-	logger := getLogger("genS3")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genS3 get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-S3",
@@ -90,7 +90,7 @@ func GenerateS3GetHandler(ctx echo.Context) error {
 }
 
 func GenerateGCPGetHandler(ctx echo.Context) error {
-	logger := getLogger("genGCP")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genGCP get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-GCP",
@@ -102,7 +102,7 @@ func GenerateGCPGetHandler(ctx echo.Context) error {
 
 func GenerateNCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("genNCP")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genNCP get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-NCP",
@@ -114,7 +114,7 @@ func GenerateNCPGetHandler(ctx echo.Context) error {
 
 func GenerateMySQLGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("genmysql")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genmysql get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-MySQL",
@@ -124,7 +124,7 @@ func GenerateMySQLGetHandler(ctx echo.Context) error {
 }
 
 func GenerateDynamoDBGetHandler(ctx echo.Context) error {
-	logger := getLogger("gendynamodb")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("gendynamodb get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-DynamoDB",
@@ -135,7 +135,7 @@ func GenerateDynamoDBGetHandler(ctx echo.Context) error {
 }
 
 func GenerateFirestoreGetHandler(ctx echo.Context) error {
-	logger := getLogger("genfirestore")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genfirestore get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-Firestore",
@@ -146,7 +146,7 @@ func GenerateFirestoreGetHandler(ctx echo.Context) error {
 }
 
 func GenerateMongoDBGetHandler(ctx echo.Context) error {
-	logger := getLogger("genfirestore")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("genmongodb get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Generate-MongoDB",
@@ -160,7 +160,7 @@ func GenerateMongoDBGetHandler(ctx echo.Context) error {
 // Page handlers related to backup data
 
 func BackupHandler(ctx echo.Context) error {
-	logger := getLogger("backup")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("backup get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Backup",
@@ -176,7 +176,7 @@ func BackupHandler(ctx echo.Context) error {
 // Page handlers related to backup data
 
 func RestoreHandler(ctx echo.Context) error {
-	logger := getLogger("restore")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("restore get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Restore",
@@ -194,7 +194,7 @@ func RestoreHandler(ctx echo.Context) error {
 // linux to object storage
 
 func MigrationLinuxToS3GetHandler(ctx echo.Context) error {
-	logger := getLogger("miglins3")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miglinux get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Linux-S3",
@@ -205,7 +205,7 @@ func MigrationLinuxToS3GetHandler(ctx echo.Context) error {
 }
 
 func MigrationLinuxToGCPGetHandler(ctx echo.Context) error {
-	logger := getLogger("miglingcp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miglingcp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Linux-GCP",
@@ -217,7 +217,7 @@ func MigrationLinuxToGCPGetHandler(ctx echo.Context) error {
 
 func MigrationLinuxToNCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("miglinncp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miglinncp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Linux-NCP",
@@ -231,7 +231,7 @@ func MigrationLinuxToNCPGetHandler(ctx echo.Context) error {
 
 func MigrationWindowsToS3GetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
-	logger := getLogger("migwins3")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migwins3 get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Windows-S3",
@@ -245,7 +245,7 @@ func MigrationWindowsToS3GetHandler(ctx echo.Context) error {
 
 func MigrationWindowsToGCPGetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
-	logger := getLogger("migwingcp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migwingcp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Windows-GCP",
@@ -259,7 +259,7 @@ func MigrationWindowsToGCPGetHandler(ctx echo.Context) error {
 func MigrationWindowsToNCPGetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
 
-	logger := getLogger("migwinncp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migwinncp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Windows-NCP",
@@ -274,7 +274,7 @@ func MigrationWindowsToNCPGetHandler(ctx echo.Context) error {
 
 func MigrationMySQLGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migmysql")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migmysql get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-MySQL",
@@ -288,7 +288,7 @@ func MigrationMySQLGetHandler(ctx echo.Context) error {
 
 func MigrationS3ToLinuxGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migs3lin")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migs3lin get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-S3-Linux",
@@ -301,7 +301,7 @@ func MigrationS3ToLinuxGetHandler(ctx echo.Context) error {
 func MigrationS3ToWindowsGetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
 
-	logger := getLogger("migs3win")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migs3win get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-S3-Windows",
@@ -314,7 +314,7 @@ func MigrationS3ToWindowsGetHandler(ctx echo.Context) error {
 
 func MigrationS3ToGCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migs3gcp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migs3gcp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-S3-GCP",
@@ -327,7 +327,7 @@ func MigrationS3ToGCPGetHandler(ctx echo.Context) error {
 
 func MigrationS3ToNCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migs3ncp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migs3ncp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-S3-NCP",
@@ -343,7 +343,7 @@ func MigrationS3ToNCPGetHandler(ctx echo.Context) error {
 
 func MigrationGCPToLinuxGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("miggcplin")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miggcplin get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-GCP-Linux",
@@ -356,7 +356,7 @@ func MigrationGCPToLinuxGetHandler(ctx echo.Context) error {
 func MigrationGCPToWindowsGetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
 
-	logger := getLogger("miggcpwin")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miggcpwin get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-GCP-Windows",
@@ -380,7 +380,7 @@ func MigrationGCPToS3GetHandler(ctx echo.Context) error {
 
 func MigrationGCPToNCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("miggcpncp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("miggcpncp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-GCP-NCP",
@@ -396,7 +396,7 @@ func MigrationGCPToNCPGetHandler(ctx echo.Context) error {
 
 func MigrationNCPToLinuxGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migncplin")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migncplin get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-NCP-Linux",
@@ -409,7 +409,7 @@ func MigrationNCPToLinuxGetHandler(ctx echo.Context) error {
 func MigrationNCPToWindowsGetHandler(ctx echo.Context) error {
 	tmpPath := filepath.Join(os.TempDir(), "dummy")
 
-	logger := getLogger("migncpwin")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migncpwin get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-NCP-Windows",
@@ -422,7 +422,7 @@ func MigrationNCPToWindowsGetHandler(ctx echo.Context) error {
 
 func MigrationNCPToS3GetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migncps3")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migncps3 get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-NCP-S3",
@@ -435,7 +435,7 @@ func MigrationNCPToS3GetHandler(ctx echo.Context) error {
 
 func MigrationNCPToGCPGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migncpgcp")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migncpgcp get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-NCP-GCP",
@@ -451,7 +451,7 @@ func MigrationNCPToGCPGetHandler(ctx echo.Context) error {
 
 func MigrationDynamoDBToFirestoreGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migDNFS")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migDNFS get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-DynamoDB-Firestore",
@@ -464,7 +464,7 @@ func MigrationDynamoDBToFirestoreGetHandler(ctx echo.Context) error {
 
 func MigrationDynamoDBToMongoDBGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migDNMG")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migDNMG get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-DynamoDB-MongoDB",
@@ -479,7 +479,7 @@ func MigrationDynamoDBToMongoDBGetHandler(ctx echo.Context) error {
 
 func MigrationFirestoreToDynamoDBGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migFSDN")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migFSDN get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content:    "Migration-Firestore-DynamoDB",
@@ -492,7 +492,7 @@ func MigrationFirestoreToDynamoDBGetHandler(ctx echo.Context) error {
 
 func MigrationFirestoreToMongoDBGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migFSMG")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migFSMG get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-Firestore-MongoDB",
@@ -507,7 +507,7 @@ func MigrationFirestoreToMongoDBGetHandler(ctx echo.Context) error {
 
 func MigrationMongoDBToDynamoDBGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migMGDN")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migMGDN get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-MongoDB-DynamoDB",
@@ -519,7 +519,7 @@ func MigrationMongoDBToDynamoDBGetHandler(ctx echo.Context) error {
 
 func MigrationMongoDBToFirestoreGetHandler(ctx echo.Context) error {
 
-	logger := getLogger("migMGFS")
+	logger := getLoggerFromContext(ctx)
 	logger.Info().Msg("migMGFS get page accessed")
 	return ctx.Render(http.StatusOK, "index.html", models.BasicPageResponse{
 		Content: "Migration-MongoDB-Firestore",

--- a/websrc/controllers/publicfunc.go
+++ b/websrc/controllers/publicfunc.go
@@ -45,24 +45,22 @@ import (
 	"github.com/cloud-barista/mc-data-manager/service/rdbc"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cast"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func getLogger(jobName string) *zerolog.Logger {
-	logger := log.With().Str("serviceType", jobName).Str("taskType", jobName).Logger()
-	return &logger
+func getLoggerFromContext(c echo.Context) *zerolog.Logger {
+	// Retrieve the logger from the request context
+	return zerolog.Ctx(c.Request().Context())
 }
-
-func pageLogInit(pageName, pageInfo string, startTime time.Time) (*zerolog.Logger, *strings.Builder) {
-	logger := getLogger(pageName)
+func pageLogInit(c echo.Context, pageName, pageInfo string, startTime time.Time) (*zerolog.Logger, *strings.Builder) {
+	logger := getLoggerFromContext(c)
 	var logstrings strings.Builder
 
+	// Log page access information
 	logger.Info().Msgf("%s post page accessed", pageName)
-
 	logger.Info().Msg(pageInfo)
-	logger.Info().Str("start time", startTime.Format("2006-01-02T15:04:05-07:00")).Msg("")
+	logger.Info().Str("start time", startTime.Format(time.RFC3339)).Msg("")
 
 	return logger, &logstrings
 }

--- a/websrc/controllers/restoreHandlers.go
+++ b/websrc/controllers/restoreHandlers.go
@@ -46,7 +46,7 @@ import (
 //	@Router			/restore/objectstorage [post]
 func RestoreOSPostHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Restore-objectstorage", "Import data to objectstorage", start)
+	logger, logstrings := pageLogInit(ctx, "Restore-objectstorage", "Import data to objectstorage", start)
 	params := models.RestoreTask{}
 	if !getDataWithReBind(logger, start, ctx, &params) {
 		log.Error().Msgf("Req params err")
@@ -91,7 +91,7 @@ func RestoreRDBPostHandler(ctx echo.Context) error {
 
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("restore-sql", "Import data to mysql", start)
+	logger, logstrings := pageLogInit(ctx, "restore-sql", "Import data to mysql", start)
 
 	params := models.RestoreTask{}
 	if !getDataWithBind(logger, start, ctx, &params) {
@@ -178,7 +178,7 @@ func RestoreNRDBPostHandler(ctx echo.Context) error {
 	var err error
 	start := time.Now()
 
-	logger, logstrings := pageLogInit("Restore-nrdb", "Import data from nrdb", start)
+	logger, logstrings := pageLogInit(ctx, "Restore-nrdb", "Import data from nrdb", start)
 
 	params := models.RestoreTask{}
 	if !getDataWithReBind(logger, start, ctx, &params) {

--- a/websrc/controllers/taskHandlers.go
+++ b/websrc/controllers/taskHandlers.go
@@ -41,7 +41,7 @@ type TaskController struct {
 //	@Router			/task [get]
 func (tc *TaskController) GetAllTasksHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Get-task-list", "Get an existing task", start)
+	logger, logstrings := pageLogInit(ctx, "Get-task-list", "Get an existing task", start)
 	tasks, err := tc.TaskService.GetScheduleList()
 	if err != nil {
 		errStr := err.Error()
@@ -69,7 +69,7 @@ func (tc *TaskController) GetAllTasksHandler(ctx echo.Context) error {
 //	@Router			/task [post]
 func (tc *TaskController) CreateTaskHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Create-task", "Creating a new task", start)
+	logger, logstrings := pageLogInit(ctx, "Create-task", "Creating a new task", start)
 	params := models.Schedule{}
 	if !getDataWithReBind(logger, start, ctx, &params) {
 		errStr := "Invalid request data"
@@ -108,7 +108,7 @@ func (tc *TaskController) CreateTaskHandler(ctx echo.Context) error {
 //	@Router			/task/{id} [get]
 func (tc *TaskController) GetTaskHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Get-task", "Get an existing task", start)
+	logger, logstrings := pageLogInit(ctx, "Get-task", "Get an existing task", start)
 	id := ctx.Param("id")
 	task, err := tc.TaskService.GetSchedule(id)
 	if err != nil {
@@ -139,7 +139,7 @@ func (tc *TaskController) GetTaskHandler(ctx echo.Context) error {
 //	@Router			/task/{id} [put]
 func (tc *TaskController) UpdateTaskHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Update-task", "Updating an existing task", start)
+	logger, logstrings := pageLogInit(ctx, "Update-task", "Updating an existing task", start)
 	id := ctx.Param("id")
 	params := models.Schedule{}
 	if !getDataWithReBind(logger, start, ctx, &params) {
@@ -178,7 +178,7 @@ func (tc *TaskController) UpdateTaskHandler(ctx echo.Context) error {
 //	@Router			/task/{id} [delete]
 func (tc *TaskController) DeleteTaskHandler(ctx echo.Context) error {
 	start := time.Now()
-	logger, logstrings := pageLogInit("Delete-task", "Delete an existing task", start)
+	logger, logstrings := pageLogInit(ctx, "Delete-task", "Delete an existing task", start)
 	id := ctx.Param("id")
 	if err := tc.TaskService.DeleteSchedule(id); err != nil {
 		errStr := "Task not found"

--- a/websrc/docs/docs.go
+++ b/websrc/docs/docs.go
@@ -33,7 +33,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[RDBMS]"
                 ],
                 "summary": "Export data from MySQL",
@@ -74,7 +74,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[Object Storage]"
                 ],
                 "summary": "Export data from objectstorage",
@@ -115,7 +115,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[RDBMS]"
                 ],
                 "summary": "Export data from MySQL",
@@ -1696,7 +1696,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[RDBMS]"
                 ],
                 "summary": "Import data from MySQL",
@@ -1738,7 +1738,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[Object Storage]"
                 ],
                 "summary": "Import data from objectstorage",
@@ -1780,7 +1780,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[RDBMS]"
                 ],
                 "summary": "Import data from MySQL",

--- a/websrc/docs/swagger.json
+++ b/websrc/docs/swagger.json
@@ -26,7 +26,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[RDBMS]"
                 ],
                 "summary": "Export data from MySQL",
@@ -67,7 +67,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[Object Storage]"
                 ],
                 "summary": "Export data from objectstorage",
@@ -108,7 +108,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Export]",
+                    "[Data Backup]",
                     "[RDBMS]"
                 ],
                 "summary": "Export data from MySQL",
@@ -1689,7 +1689,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[RDBMS]"
                 ],
                 "summary": "Import data from MySQL",
@@ -1731,7 +1731,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[Object Storage]"
                 ],
                 "summary": "Import data from objectstorage",
@@ -1773,7 +1773,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Data Import]",
+                    "[Data Restore]",
                     "[RDBMS]"
                 ],
                 "summary": "Import data from MySQL",

--- a/websrc/docs/swagger.yaml
+++ b/websrc/docs/swagger.yaml
@@ -231,7 +231,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Export data from MySQL
       tags:
-      - '[Data Export]'
+      - '[Data Backup]'
       - '[RDBMS]'
   /backup/objectstorage:
     post:
@@ -258,7 +258,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Export data from objectstorage
       tags:
-      - '[Data Export]'
+      - '[Data Backup]'
       - '[Object Storage]'
   /backup/rdb:
     post:
@@ -285,7 +285,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Export data from MySQL
       tags:
-      - '[Data Export]'
+      - '[Data Backup]'
       - '[RDBMS]'
   /generate/aws:
     post:
@@ -1335,7 +1335,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Import data from MySQL
       tags:
-      - '[Data Import]'
+      - '[Data Restore]'
       - '[RDBMS]'
   /restore/objectstorage:
     post:
@@ -1363,7 +1363,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Import data from objectstorage
       tags:
-      - '[Data Import]'
+      - '[Data Restore]'
       - '[Object Storage]'
   /restore/rdb:
     post:
@@ -1391,7 +1391,7 @@ paths:
             $ref: '#/definitions/models.BasicResponse'
       summary: Import data from MySQL
       tags:
-      - '[Data Import]'
+      - '[Data Restore]'
       - '[RDBMS]'
   /task:
     get:

--- a/websrc/middlewares/Tracing.go
+++ b/websrc/middlewares/Tracing.go
@@ -16,6 +16,9 @@ func TracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		// Get the context and initialize trace and span IDs
 		ctx := c.Request().Context()
 		traceId := c.Response().Header().Get(echo.HeaderXRequestID)
+		if traceId == "" {
+			traceId = fmt.Sprintf("%d", time.Now().UnixNano())
+		}
 		spanId := fmt.Sprintf("%d", time.Now().UnixNano())
 
 		// Store trace and span IDs in the context
@@ -24,17 +27,17 @@ func TracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 		// Create a logger with trace_id and span_id and store it in the context
 		requestLogger := log.With().
+			Str(string(logger.TraceIdKey), traceId).
+			Str(string(logger.SpanIdKey), spanId).
 			Str("Host", c.Request().Host).
 			Str("RemoteAddr", c.Request().RemoteAddr).
 			Str("RequestURI", c.Request().RequestURI).
+			Str("Method", c.Request().Method).
 			Str("UserAgent", c.Request().UserAgent()).
 			Str("X-Request-ID", c.Request().Header.Get("X-Request-ID")).
 			Str("X-Trace-ID", c.Request().Header.Get("X-Trace-ID")).
 			Str("X-Forwarded-For", c.Request().Header.Get("X-Forwarded-For")).
 			Str("X-Real-IP", c.Request().Header.Get("X-Real-IP")).
-			Str("Authorization", c.Request().Header.Get("Authorization")).
-			Str(string(logger.TraceIdKey), traceId).
-			Str(string(logger.SpanIdKey), spanId).
 			Caller().
 			Logger()
 
@@ -43,15 +46,29 @@ func TracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		c.SetRequest(c.Request().WithContext(ctx))
 
 		// Log the incoming request
-		log.Ctx(ctx).Info().Msg("[tracing] receive request")
+		requestLogger.Info().Msg("[tracing] receive request")
 
 		// Measure the latency
 		startTime := time.Now()
-		latency := time.Since(startTime)
-		// Log the response details
-		c.Response().Before(func() {
-			log.Ctx(ctx).Info().
-				Int("Status", c.Response().Status).
+
+		// Register the After function before calling next(c)
+		c.Response().After(func() {
+			latency := time.Since(startTime)
+			statusCode := c.Response().Status
+
+			// Choose log level based on status code
+			event := requestLogger.Info() // Default to Info level
+			if statusCode >= 500 {
+				event = requestLogger.Error()
+			} else if statusCode >= 400 {
+				event = requestLogger.Warn()
+			}
+
+			// Log the response details
+			event.
+				Str(string(logger.TraceIdKey), traceId).
+				Str(string(logger.SpanIdKey), spanId).
+				Int("Status", statusCode).
 				Int64("Latency", latency.Nanoseconds()).
 				Str("LatencyHuman", latency.String()).
 				Int64("BytesIn", c.Request().ContentLength).
@@ -59,7 +76,10 @@ func TracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 				Msg("[tracing] send response")
 		})
 
+		// Proceed to next handler
+		err := next(c)
+
 		// Return the error if any
-		return next(c)
+		return err
 	}
 }

--- a/websrc/serve/serve.go
+++ b/websrc/serve/serve.go
@@ -117,7 +117,7 @@ func InitServer(port string, addIP ...string) *echo.Echo {
 
 	// Middleware
 	e.Use(TrustedProxiesMiddleware(allowIP))
-	e.Use(middleware.Logger())
+	// e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	// Custom middleware for tracing
 	e.Use(middlewares.TracingMiddleware)


### PR DESCRIPTION
- TracingMiddleware에서 zerolog를 사용하여 API 요청 및 응답을 로깅하도록 개선하
- 응답의 상태 코드에 따라 로그 레벨을 동적으로 설정하도록 수정
- 2XX, 3XX 상태 코드: Info 레벨로 로깅
- 4XX 상태 코드: Warn 레벨로 로깅
- 5XX 상태 코드: Error 레벨로 로깅
- c.Response().After 함수를 next(c) 호출 이전에 등록, 응답 후에 정확한 로그가 출력 되도록 수정
- 로그 메시지에 요청 및 응답의 상세 정보를 포함하도록 개선하였습니다.
  - Method, URI, Status, Latency, BytesIn, BytesOut 등
- traceId와 spanId를 컨텍스트에 저장하고, 로거에 포함하여 요청의 추적 확인 완료